### PR TITLE
Fixed Dockerfile for p4-search

### DIFF
--- a/p4-search/Dockerfile
+++ b/p4-search/Dockerfile
@@ -14,7 +14,7 @@ RUN \
   
 RUN apt-get install -y helix-cli
 
-ADD http://ftp.perforce.com/perforce/r16.1/bin.java/p4search.tgz /p4search.tgz 
+ADD http://ftp.perforce.com/perforce/r22.3/bin.java/helix-p4search.tgz /p4search.tgz 
 
 RUN tar xfz /p4search.tgz
 


### PR DESCRIPTION
Seems like that there is no `bin.java` for downloading p4search at [perforce/r16.1](http://ftp.perforce.com/perforce/r16.1/) anymore so that failed to download it.
I modified it to URL for the latest version (r.22.3) and confirmed to work well.